### PR TITLE
Identifier column naming consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `laravel-ownership` will be documented in this file.
 
+## [3.0.0] - 2017-04-10
+
+### Changed
+
+- Default database column used by models with strict ownership was renamed from `owned_by` to `owned_by_id`.
+
+[Upgrade instructions]
+
 ## [2.2.0] - 2017-02-07
 
 ### Added
@@ -37,6 +45,8 @@ All notable changes to `laravel-ownership` will be documented in this file.
 
 - Initial release
 
+[3.0.0]: https://github.com/cybercog/laravel-ownership/compare/2.2.0...3.0.0
 [2.2.0]: https://github.com/cybercog/laravel-ownership/compare/2.1.0...2.2.0
 [2.1.0]: https://github.com/cybercog/laravel-ownership/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/cybercog/laravel-ownership/compare/1.0.0...2.0.0
+[Upgrade instructions]: UPGRADE.md

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Schema::table('articles', function (Blueprint $table) {
 });
 ```
 
-#### Overwrite strict ownership owner foreign key
+#### Overwrite strict ownership owner's foreign key
 
 By default owner model will be the same as `config('auth.providers.users.model')` provides.
 

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ Ownable model with strict ownership must have in database additional nullable co
 
 ```php
 Schema::table('articles', function (Blueprint $table) {
-    $table->integer('owned_by')->unsigned()->nullable();
+    $table->integer('owned_by_id')->unsigned()->nullable();
     
-    $table->index('owned_by');
+    $table->index('owned_by_id');
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Schema::table('articles', function (Blueprint $table) {
 });
 ```
 
+#### Overwrite strict ownership owner foreign key
+
 By default owner model will be the same as `config('auth.providers.users.model')` provides.
 
 To override default owner model in strict ownership, it's primary key or foreign key extend your ownable model with additional attributes:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,7 +10,7 @@ You need to upgrade only if you have models with Strict Ownership and you are us
 - Rename database columns `owned_by` to `owned_by_id` for all the ownable models with strict ownership.
 - If you have raw DB queries - don't forget to modify them as well.
 
-#### What if I want to keep old naming?!
+### What if I want to keep old naming?!
 
 You are able to keep old naming without any database changes. Overwrite foreign keys in ownable models by adding `$ownerForeignKey` property:
 
@@ -18,4 +18,4 @@ You are able to keep old naming without any database changes. Overwrite foreign 
 protected $ownerForeignKey = 'owned_by';
 ```
 
-[See example of foreign key overwrite](https://github.com/cybercog/laravel-ownership#prepare-ownable-model-with-strict-ownership)
+[See example of foreign key overwrite](https://github.com/cybercog/laravel-ownership#overwrite-strict-ownership-owner-foreign-key)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,21 @@
+# Upgrade Guide
+
+- [Upgrading To 3.0 From 2.0](#upgrade-3.0)
+
+<a name="upgrade-3.0"></a>
+## Upgrading To 3.0 From 2.0
+
+You need to upgrade only if you have models with Strict Ownership and you are using default `owned_by` column names.
+
+- Rename database columns `owned_by` to `owned_by_id` for all the ownable models with strict ownership.
+- If you have raw DB queries - don't forget to modify them as well.
+
+#### What if I want to keep old naming?!
+
+You are able to keep old naming without any database changes. Overwrite foreign keys in ownable models by adding `$ownerForeignKey` property:
+
+```php
+protected $ownerForeignKey = 'owned_by';
+```
+
+[See example of foreign key overwrite](https://github.com/cybercog/laravel-ownership#prepare-ownable-model-with-strict-ownership)

--- a/src/Traits/HasOwner.php
+++ b/src/Traits/HasOwner.php
@@ -245,6 +245,6 @@ trait HasOwner
      */
     protected function getOwnerForeignKey()
     {
-        return $this->ownerForeignKey ?: 'owned_by';
+        return $this->ownerForeignKey ?: 'owned_by_id';
     }
 }

--- a/tests/database/factories/EntityWithDefaultOwnerFactory.php
+++ b/tests/database/factories/EntityWithDefaultOwnerFactory.php
@@ -12,6 +12,6 @@
 $factory->define(\Cog\Ownership\Tests\Stubs\Models\EntityWithDefaultOwner::class, function (\Faker\Generator $faker) {
     return [
         'name' => $faker->word,
-        'owned_by' => null,
+        'owned_by_id' => null,
     ];
 });

--- a/tests/database/factories/EntityWithOwnerFactory.php
+++ b/tests/database/factories/EntityWithOwnerFactory.php
@@ -12,6 +12,6 @@
 $factory->define(\Cog\Ownership\Tests\Stubs\Models\EntityWithOwner::class, function (\Faker\Generator $faker) {
     return [
         'name' => $faker->word,
-        'owned_by' => null,
+        'owned_by_id' => null,
     ];
 });

--- a/tests/database/migrations/2016_12_15_000000_create_entity_with_owner_table.php
+++ b/tests/database/migrations/2016_12_15_000000_create_entity_with_owner_table.php
@@ -28,7 +28,7 @@ class CreateEntityWithOwnerTable extends Migration
         Schema::create('entity_with_owner', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
-            $table->integer('owned_by')->unsigned()->nullable();
+            $table->integer('owned_by_id')->unsigned()->nullable();
             $table->timestamps();
         });
     }

--- a/tests/unit/Traits/HasOwnerTest.php
+++ b/tests/unit/Traits/HasOwnerTest.php
@@ -31,7 +31,7 @@ class HasOwnerTest extends TestCase
     {
         $user = factory(User::class)->create();
         $entity = factory(EntityWithOwner::class)->create([
-            'owned_by' => $user->getKey(),
+            'owned_by_id' => $user->getKey(),
         ]);
 
         $this->assertInstanceOf(BelongsTo::class, $entity->ownedBy());
@@ -42,7 +42,7 @@ class HasOwnerTest extends TestCase
     {
         $user = factory(User::class)->create();
         $entity = factory(EntityWithOwner::class)->create([
-            'owned_by' => $user->getKey(),
+            'owned_by_id' => $user->getKey(),
         ]);
 
         $this->assertInstanceOf(BelongsTo::class, $entity->owner());
@@ -53,7 +53,7 @@ class HasOwnerTest extends TestCase
     {
         $user = factory(User::class)->create();
         $entity = factory(EntityWithOwner::class)->create([
-            'owned_by' => $user->getKey(),
+            'owned_by_id' => $user->getKey(),
         ]);
 
         $this->assertInstanceOf(User::class, $entity->ownedBy);
@@ -64,7 +64,7 @@ class HasOwnerTest extends TestCase
     {
         $user = factory(User::class)->create();
         $entity = factory(EntityWithOwner::class)->create([
-            'owned_by' => $user->getKey(),
+            'owned_by_id' => $user->getKey(),
         ]);
 
         $this->assertInstanceOf(User::class, $entity->owner);
@@ -75,7 +75,7 @@ class HasOwnerTest extends TestCase
     {
         $user = factory(User::class)->create();
         $entity = factory(EntityWithOwner::class)->create([
-            'owned_by' => $user->getKey(),
+            'owned_by_id' => $user->getKey(),
         ]);
 
         $this->assertInstanceOf(User::class, $entity->getOwner());
@@ -87,7 +87,7 @@ class HasOwnerTest extends TestCase
         $user = factory(User::class)->create();
         $newUser = factory(User::class)->create();
         $entity = factory(EntityWithOwner::class)->create([
-            'owned_by' => $user->getKey(),
+            'owned_by_id' => $user->getKey(),
         ]);
         $entity->changeOwnerTo($newUser);
 
@@ -99,7 +99,7 @@ class HasOwnerTest extends TestCase
     {
         $user = factory(User::class)->create();
         $entity = factory(EntityWithOwner::class)->create([
-            'owned_by' => $user->getKey(),
+            'owned_by_id' => $user->getKey(),
         ]);
         $this->assertInstanceOf(User::class, $entity->getOwner());
 
@@ -113,7 +113,7 @@ class HasOwnerTest extends TestCase
     {
         $user = factory(User::class)->create();
         $entity = factory(EntityWithOwner::class)->create([
-            'owned_by' => $user->getKey(),
+            'owned_by_id' => $user->getKey(),
         ]);
 
         $this->assertTrue($entity->hasOwner());
@@ -123,7 +123,7 @@ class HasOwnerTest extends TestCase
     public function it_can_check_if_dont_have_owner()
     {
         $entity = factory(EntityWithOwner::class)->create([
-            'owned_by' => null,
+            'owned_by_id' => null,
         ]);
 
         $this->assertFalse($entity->hasOwner());
@@ -134,7 +134,7 @@ class HasOwnerTest extends TestCase
     {
         $user = factory(User::class)->create();
         $entity = factory(EntityWithOwner::class)->create([
-            'owned_by' => $user->getKey(),
+            'owned_by_id' => $user->getKey(),
         ]);
 
         $this->assertTrue($entity->isOwnedBy($user));
@@ -145,7 +145,7 @@ class HasOwnerTest extends TestCase
     {
         $user = factory(User::class)->create();
         $entity = factory(EntityWithOwner::class)->create([
-            'owned_by' => $user->getKey(),
+            'owned_by_id' => $user->getKey(),
         ]);
         $notOwnerUser = factory(User::class)->create();
 
@@ -157,7 +157,7 @@ class HasOwnerTest extends TestCase
     {
         $user = factory(User::class)->create();
         $entity = factory(EntityWithOwner::class)->create([
-            'owned_by' => $user->getKey(),
+            'owned_by_id' => $user->getKey(),
         ]);
         $notOwnerUser = factory(User::class)->create();
 
@@ -169,7 +169,7 @@ class HasOwnerTest extends TestCase
     {
         $user = factory(User::class)->create();
         $entity = factory(EntityWithOwner::class)->create([
-            'owned_by' => $user->getKey(),
+            'owned_by_id' => $user->getKey(),
         ]);
 
         $this->assertFalse($entity->isNotOwnedBy($user));
@@ -180,11 +180,11 @@ class HasOwnerTest extends TestCase
     {
         $user1 = factory(User::class)->create();
         factory(EntityWithOwner::class, 4)->create([
-            'owned_by' => $user1->getKey(),
+            'owned_by_id' => $user1->getKey(),
         ]);
         $user2 = factory(User::class)->create();
         factory(EntityWithOwner::class, 3)->create([
-            'owned_by' => $user2->getKey(),
+            'owned_by_id' => $user2->getKey(),
         ]);
 
         $this->assertCount(4, EntityWithOwner::whereOwnedBy($user1)->get());
@@ -195,11 +195,11 @@ class HasOwnerTest extends TestCase
     {
         $user1 = factory(User::class)->create();
         factory(EntityWithOwner::class, 4)->create([
-            'owned_by' => $user1->getKey(),
+            'owned_by_id' => $user1->getKey(),
         ]);
         $user2 = factory(User::class)->create();
         factory(EntityWithOwner::class, 3)->create([
-            'owned_by' => $user2->getKey(),
+            'owned_by_id' => $user2->getKey(),
         ]);
 
         $this->assertCount(3, EntityWithOwner::whereNotOwnedBy($user1)->get());
@@ -211,7 +211,7 @@ class HasOwnerTest extends TestCase
         $user = factory(User::class)->create();
         $this->actingAs($user);
         $entity = factory(EntityWithDefaultOwner::class)->make([
-            'owned_by' => null,
+            'owned_by_id' => null,
         ]);
         $entity->save();
 
@@ -222,7 +222,7 @@ class HasOwnerTest extends TestCase
     public function it_cannot_set_default_owner_on_create_for_guest()
     {
         $entity = factory(EntityWithDefaultOwner::class)->make([
-            'owned_by' => null,
+            'owned_by_id' => null,
         ]);
         $entity->save();
 
@@ -235,7 +235,7 @@ class HasOwnerTest extends TestCase
         $user = factory(User::class)->create();
         $this->actingAs($user);
         $entity = factory(EntityWithOwner::class)->make([
-            'owned_by' => null,
+            'owned_by_id' => null,
         ]);
         $entity->withDefaultOwner()->save();
 
@@ -249,7 +249,7 @@ class HasOwnerTest extends TestCase
         $user2 = factory(User::class)->create();
         $this->actingAs($user);
         $entity = factory(EntityWithOwner::class)->make([
-            'owned_by' => null,
+            'owned_by_id' => null,
         ]);
         $entity->withDefaultOwner($user2)->save();
 
@@ -264,7 +264,7 @@ class HasOwnerTest extends TestCase
         $user2 = factory(User::class)->create();
         $this->actingAs($user);
         $entity = factory(EntityWithDefaultOwner::class)->make([
-            'owned_by' => null,
+            'owned_by_id' => null,
         ]);
         $entity->withDefaultOwner($user2)->save();
 
@@ -278,7 +278,7 @@ class HasOwnerTest extends TestCase
         $user = factory(User::class)->create();
         $this->actingAs($user);
         $entity = factory(EntityWithDefaultOwner::class)->make([
-            'owned_by' => null,
+            'owned_by_id' => null,
         ]);
         $entity->withoutDefaultOwner()->save();
 


### PR DESCRIPTION
It's a pretty small change but it's breaking. Default database column used by models with strict (not polymorphic) ownership was renamed from `owned_by` to `owned_by_id`.

The main reason of naming changes was unification of both types of the ownerships which allows to swap from Strict Ownership to Polymorphic Ownership with zero-downtime.

#### What if I want to keep old naming?!

Take it easy. You are able to keep old naming without any database changes. Overwrite foreign keys in ownable models by adding `$ownerForeignKey` property:

```php
protected $ownerForeignKey = 'owned_by';
```
[See example of foreign key overwrite](https://github.com/cybercog/laravel-ownership#prepare-ownable-model-with-strict-ownership)

#### What should be done to upgrade to new package version?

- Rename database columns `owned_by` to `owned_by_id` for all the ownable models with strict ownership.
- If you have raw DB queries - don't forget to modify them as well.

#### How the migration to Polymorphic Ownership will look like?

If your decided to make your ownable model polymorphic you need to perform 5 steps.

To migrate Model with Strict Ownership to Polymorphic Ownership all you need to do:
- add `owned_by_type` column with default value of the current owner's `getMorphClass()` value;
- create index of 2 columns 'owned_by_id' + 'owned_by_type';
- deploy your code.

After all the project checked and working well we are doing cleanup:
- drop old `owned_by_id` index;
- remove default value from `owned_by_type` column (it is required only for the case while somebody creates ownable model right at the moment of your deployment process and codebase isn't in place yet, but database already has new structure and null value in type column isn't a good thing when you are working with polymorphic entities).