### PR TITLE
Release 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `laravel-ownership` will be documented in this file.
 
+## [5.0.0] - 2017-09-13
+
+### Changed
+
+- Contracts namespace changed from `Cog\Contracts\Laravel\Ownership` to `Cog\Contracts\Ownership`
+
+### Fixed
+
+- Service Provider auto-discovery
+
 ## [4.0.0] - 2017-09-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Polymorphic ownership is useful when model can belongs to owners of different ty
 Use `Ownable` contract in model which will get ownership behavior and implement it or just use `HasOwner` trait. 
 
 ```php
-use Cog\Contracts\Laravel\Ownership\Ownable as OwnableContract;
+use Cog\Contracts\Ownership\Ownable as OwnableContract;
 use Cog\Laravel\Ownership\Traits\HasOwner;
 use Illuminate\Database\Eloquent\Model;
 
@@ -106,7 +106,7 @@ By default owner model will be the same as `config('auth.providers.users.model')
 To override default owner model in strict ownership, it's primary key or foreign key extend your ownable model with additional attributes:
 
 ```php
-use Cog\Contracts\Laravel\Ownership\Ownable as OwnableContract;
+use Cog\Contracts\Ownership\Ownable as OwnableContract;
 use Cog\Laravel\Ownership\Traits\HasOwner;
 use Illuminate\Database\Eloquent\Model;
 
@@ -125,7 +125,7 @@ class Article extends Model implements OwnableContract
 Use `Ownable` contract in model which will get polymorphic ownership behavior and implement it or just use `HasMorphOwner` trait. 
 
 ```php
-use Cog\Contracts\Laravel\Ownership\Ownable as OwnableContract;
+use Cog\Contracts\Ownership\Ownable as OwnableContract;
 use Cog\Laravel\Ownership\Traits\HasMorphOwner;
 use Illuminate\Database\Eloquent\Model;
 
@@ -249,7 +249,7 @@ Article::whereNotOwnedBy($owner)->get();
 To set currently authenticated user as owner for ownable model create - extend it with attribute `withDefaultOwnerOnCreate`. It works for both strict and polymorphic ownership behavior.
 
 ```php
-use Cog\Contracts\Laravel\Ownership\Ownable as OwnableContract;
+use Cog\Contracts\Ownership\Ownable as OwnableContract;
 use Cog\Laravel\Ownership\Traits\HasOwner;
 use Illuminate\Database\Eloquent\Model;
 
@@ -264,7 +264,7 @@ class Article extends Model implements OwnableContract
 To override strategy of getting default owner extend ownable model with `resolveDefaultOwner` method:
 
 ```php
-use Cog\Contracts\Laravel\Ownership\Ownable as OwnableContract;
+use Cog\Contracts\Ownership\Ownable as OwnableContract;
 use Cog\Laravel\Ownership\Traits\HasOwner;
 use Illuminate\Database\Eloquent\Model;
 
@@ -277,7 +277,7 @@ class Article extends Model implements OwnableContract
     /**
      * Resolve entity default owner.
      * 
-     * @return \Cog\Contracts\Laravel\Ownership\CanBeOwner|null
+     * @return null|\Cog\Contracts\Ownership\CanBeOwner
      */
     public function resolveDefaultOwner()
     {

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,9 +1,15 @@
 # Upgrade Guide
 
+- [Upgrading From 4.0 To 5.0](#upgrade-5.0)
 - [Upgrading From 3.0 To 4.0](#upgrade-4.0)
 - [Upgrading From 2.0 To 3.0](#upgrade-3.0)
 
-<a name="upgrade-3.0"></a>
+<a name="upgrade-5.0"></a>
+## Upgrading From 4.0 To 5.0
+
+- Find all `Cog\Contracts\Laravel\Ownership` and replace with `Cog\Contracts\Ownership`
+
+<a name="upgrade-4.0"></a>
 ## Upgrading From 3.0 To 4.0
 
 - Find all `Cog\Ownership\Contracts\HasOwner` and replace with `Cog\Contracts\Laravel\Ownership\Ownable`

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Cog\\Contracts\\Laravel\\Ownership\\": "contracts/",
+            "Cog\\Contracts\\Ownership\\": "contracts/",
             "Cog\\Laravel\\Ownership\\": "src/"
         }
     },
@@ -71,7 +71,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Cog\\Ownership\\Providers\\OwnershipServiceProvider"
+                "Cog\\Laravel\\Ownership\\Providers\\OwnershipServiceProvider"
             ]
         }
     },

--- a/contracts/CanBeOwner.php
+++ b/contracts/CanBeOwner.php
@@ -9,12 +9,12 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Contracts\Laravel\Ownership;
+namespace Cog\Contracts\Ownership;
 
 /**
  * Interface CanBeOwner.
  *
- * @package Cog\Contracts\Laravel\Ownership
+ * @package Cog\Contracts\Ownership
  */
 interface CanBeOwner
 {

--- a/contracts/Exceptions/InvalidDefaultOwner.php
+++ b/contracts/Exceptions/InvalidDefaultOwner.php
@@ -9,22 +9,22 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Contracts\Laravel\Ownership\Exceptions;
+namespace Cog\Contracts\Ownership\Exceptions;
 
-use Cog\Contracts\Laravel\Ownership\Ownable as OwnableContract;
+use Cog\Contracts\Ownership\Ownable as OwnableContract;
 use Exception;
 
 /**
  * Class InvalidDefaultOwner.
  *
- * @package Cog\Contracts\Laravel\Ownership\Exceptions
+ * @package Cog\Contracts\Ownership\Exceptions
  */
 class InvalidDefaultOwner extends Exception
 {
     /**
      * Default owner for ownable model is null.
      *
-     * @param \Cog\Contracts\Laravel\Ownership\Ownable $ownable
+     * @param \Cog\Contracts\Ownership\Ownable $ownable
      * @return static
      */
     public static function isNull(OwnableContract $ownable)

--- a/contracts/Exceptions/InvalidOwnerType.php
+++ b/contracts/Exceptions/InvalidOwnerType.php
@@ -9,24 +9,24 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Contracts\Laravel\Ownership\Exceptions;
+namespace Cog\Contracts\Ownership\Exceptions;
 
-use Cog\Contracts\Laravel\Ownership\Ownable as OwnableContract;
+use Cog\Contracts\Ownership\Ownable as OwnableContract;
+use Cog\Contracts\Ownership\CanBeOwner as CanBeOwnerContract;
 use Exception;
-use Cog\Contracts\Laravel\Ownership\CanBeOwner as CanBeOwnerContract;
 
 /**
  * Class InvalidOwnerType.
  *
- * @package Cog\Contracts\Laravel\Ownership\Exceptions
+ * @package Cog\Contracts\Ownership\Exceptions
  */
 class InvalidOwnerType extends Exception
 {
     /**
      * Owner of the provided type is not allowed to own this model.
      *
-     * @param \Cog\Contracts\Laravel\Ownership\Ownable $ownable
-     * @param \Cog\Contracts\Laravel\Ownership\CanBeOwner $owner
+     * @param \Cog\Contracts\Ownership\Ownable $ownable
+     * @param \Cog\Contracts\Ownership\CanBeOwner $owner
      * @return static
      */
     public static function notAllowed(OwnableContract $ownable, CanBeOwnerContract $owner)

--- a/contracts/Ownable.php
+++ b/contracts/Ownable.php
@@ -9,15 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Contracts\Laravel\Ownership;
+namespace Cog\Contracts\Ownership;
 
+use Cog\Contracts\Ownership\CanBeOwner as CanBeOwnerContract;
 use Illuminate\Database\Eloquent\Builder;
-use Cog\Contracts\Laravel\Ownership\CanBeOwner as CanBeOwnerContract;
 
 /**
  * Interface Ownable.
  *
- * @package Cog\Contracts\Laravel\Ownership
+ * @package Cog\Contracts\Ownership
  */
 interface Ownable
 {
@@ -38,29 +38,29 @@ interface Ownable
     /**
      * Get the model owner.
      *
-     * @return \Cog\Contracts\Laravel\Ownership\CanBeOwner
+     * @return \Cog\Contracts\Ownership\CanBeOwner
      */
     public function getOwner();
 
     /**
      * Get default owner.
      *
-     * @return null|\Cog\Contracts\Laravel\Ownership\CanBeOwner
+     * @return null|\Cog\Contracts\Ownership\CanBeOwner
      */
     public function defaultOwner();
 
     /**
      * Set owner as default for entity.
      *
-     * @param null|\Cog\Contracts\Laravel\Ownership\CanBeOwner $owner
-     * @return \Cog\Contracts\Laravel\Ownership\Ownable
+     * @param null|\Cog\Contracts\Ownership\CanBeOwner $owner
+     * @return \Cog\Contracts\Ownership\Ownable
      */
     public function withDefaultOwner(CanBeOwnerContract $owner = null);
 
     /**
      * Remove default owner for entity.
      *
-     * @return \Cog\Contracts\Laravel\Ownership\Ownable
+     * @return \Cog\Contracts\Ownership\Ownable
      */
     public function withoutDefaultOwner();
 
@@ -74,22 +74,22 @@ interface Ownable
     /**
      * Resolve entity default owner.
      *
-     * @return null|\Cog\Contracts\Laravel\Ownership\CanBeOwner
+     * @return null|\Cog\Contracts\Ownership\CanBeOwner
      */
     public function resolveDefaultOwner();
 
     /**
      * Changes owner of the model.
      *
-     * @param \Cog\Contracts\Laravel\Ownership\CanBeOwner $owner
-     * @return \Cog\Contracts\Laravel\Ownership\Ownable
+     * @param \Cog\Contracts\Ownership\CanBeOwner $owner
+     * @return \Cog\Contracts\Ownership\Ownable
      */
     public function changeOwnerTo(CanBeOwnerContract $owner);
 
     /**
      * Abandons owner of the model.
      *
-     * @return \Cog\Contracts\Laravel\Ownership\Ownable
+     * @return \Cog\Contracts\Ownership\Ownable
      */
     public function abandonOwner();
 
@@ -103,7 +103,7 @@ interface Ownable
     /**
      * Checks if model owned by given owner.
      *
-     * @param \Cog\Contracts\Laravel\Ownership\CanBeOwner $owner
+     * @param \Cog\Contracts\Ownership\CanBeOwner $owner
      * @return bool
      */
     public function isOwnedBy(CanBeOwnerContract $owner);
@@ -111,7 +111,7 @@ interface Ownable
     /**
      * Checks if model not owned by given owner.
      *
-     * @param \Cog\Contracts\Laravel\Ownership\CanBeOwner $owner
+     * @param \Cog\Contracts\Ownership\CanBeOwner $owner
      * @return bool
      */
     public function isNotOwnedBy(CanBeOwnerContract $owner);
@@ -120,7 +120,7 @@ interface Ownable
      * Scope a query to only include models by owner.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param \Cog\Contracts\Laravel\Ownership\CanBeOwner $owner
+     * @param \Cog\Contracts\Ownership\CanBeOwner $owner
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeWhereOwnedBy(Builder $query, CanBeOwnerContract $owner);
@@ -129,7 +129,7 @@ interface Ownable
      * Scope a query to only include models by owner.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param \Cog\Contracts\Laravel\Ownership\CanBeOwner $owner
+     * @param \Cog\Contracts\Ownership\CanBeOwner $owner
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeWhereNotOwnedBy(Builder $query, CanBeOwnerContract $owner);

--- a/src/Observers/OwnableObserver.php
+++ b/src/Observers/OwnableObserver.php
@@ -11,7 +11,7 @@
 
 namespace Cog\Laravel\Ownership\Observers;
 
-use Cog\Contracts\Laravel\Ownership\Ownable as OwnableContract;
+use Cog\Contracts\Ownership\Ownable as OwnableContract;
 
 /**
  * Class OwnableObserver.
@@ -23,7 +23,7 @@ class OwnableObserver
     /**
      * Handle the deleted event for the model.
      *
-     * @param \Cog\Contracts\Laravel\Ownership\Ownable $ownable
+     * @param \Cog\Contracts\Ownership\Ownable $ownable
      * @return void
      */
     public function creating(OwnableContract $ownable)

--- a/src/Providers/OwnershipServiceProvider.php
+++ b/src/Providers/OwnershipServiceProvider.php
@@ -13,7 +13,7 @@ namespace Cog\Laravel\Ownership\Providers;
 
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 use Illuminate\Support\ServiceProvider;
-use Cog\Contracts\Laravel\Ownership\CanBeOwner as CanBeOwnerContract;
+use Cog\Contracts\Ownership\CanBeOwner as CanBeOwnerContract;
 
 /**
  * Class OwnershipServiceProvider.

--- a/src/Traits/HasMorphOwner.php
+++ b/src/Traits/HasMorphOwner.php
@@ -11,11 +11,11 @@
 
 namespace Cog\Laravel\Ownership\Traits;
 
-use Cog\Contracts\Laravel\Ownership\Exceptions\InvalidDefaultOwner;
+use Cog\Contracts\Ownership\Exceptions\InvalidDefaultOwner;
 use Cog\Laravel\Ownership\Observers\OwnableObserver;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Database\Eloquent\Builder;
-use Cog\Contracts\Laravel\Ownership\CanBeOwner as CanBeOwnerContract;
+use Cog\Contracts\Ownership\CanBeOwner as CanBeOwnerContract;
 
 /**
  * Class HasMorphOwner.
@@ -25,7 +25,7 @@ use Cog\Contracts\Laravel\Ownership\CanBeOwner as CanBeOwnerContract;
 trait HasMorphOwner
 {
     /**
-     * @var null|\Cog\Contracts\Laravel\Ownership\CanBeOwner
+     * @var null|\Cog\Contracts\Ownership\CanBeOwner
      */
     private $defaultOwner;
 
@@ -62,7 +62,7 @@ trait HasMorphOwner
     /**
      * Get the model owner.
      *
-     * @return \Cog\Contracts\Laravel\Ownership\CanBeOwner
+     * @return \Cog\Contracts\Ownership\CanBeOwner
      */
     public function getOwner()
     {
@@ -72,7 +72,7 @@ trait HasMorphOwner
     /**
      * Get default owner.
      *
-     * @return null|\Cog\Contracts\Laravel\Ownership\CanBeOwner
+     * @return null|\Cog\Contracts\Ownership\CanBeOwner
      */
     public function defaultOwner()
     {
@@ -82,7 +82,7 @@ trait HasMorphOwner
     /**
      * Set owner as default for entity.
      *
-     * @param null|\Cog\Contracts\Laravel\Ownership\CanBeOwner $owner
+     * @param null|\Cog\Contracts\Ownership\CanBeOwner $owner
      * @return $this
      */
     public function withDefaultOwner(CanBeOwnerContract $owner = null)
@@ -123,7 +123,7 @@ trait HasMorphOwner
     /**
      * Resolve entity default owner.
      *
-     * @return null|\Cog\Contracts\Laravel\Ownership\CanBeOwner
+     * @return null|\Cog\Contracts\Ownership\CanBeOwner
      */
     public function resolveDefaultOwner()
     {
@@ -133,7 +133,7 @@ trait HasMorphOwner
     /**
      * Changes owner of the model.
      *
-     * @param \Cog\Contracts\Laravel\Ownership\CanBeOwner $owner
+     * @param \Cog\Contracts\Ownership\CanBeOwner $owner
      * @return $this
      */
     public function changeOwnerTo(CanBeOwnerContract $owner)
@@ -167,7 +167,7 @@ trait HasMorphOwner
     /**
      * Checks if model owned by given owner.
      *
-     * @param \Cog\Contracts\Laravel\Ownership\CanBeOwner $owner
+     * @param \Cog\Contracts\Ownership\CanBeOwner $owner
      * @return bool
      */
     public function isOwnedBy(CanBeOwnerContract $owner)
@@ -182,7 +182,7 @@ trait HasMorphOwner
     /**
      * Checks if model not owned by given owner.
      *
-     * @param \Cog\Contracts\Laravel\Ownership\CanBeOwner $owner
+     * @param \Cog\Contracts\Ownership\CanBeOwner $owner
      * @return bool
      */
     public function isNotOwnedBy(CanBeOwnerContract $owner)
@@ -195,7 +195,7 @@ trait HasMorphOwner
      *
      * @return bool
      *
-     * @throws \Cog\Contracts\Laravel\Ownership\Exceptions\InvalidDefaultOwner
+     * @throws \Cog\Contracts\Ownership\Exceptions\InvalidDefaultOwner
      */
     public function isOwnedByDefaultOwner()
     {
@@ -211,7 +211,7 @@ trait HasMorphOwner
      * Scope a query to only include models by owner.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param \Cog\Contracts\Laravel\Ownership\CanBeOwner $owner
+     * @param \Cog\Contracts\Ownership\CanBeOwner $owner
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeWhereOwnedBy(Builder $query, CanBeOwnerContract $owner)
@@ -226,7 +226,7 @@ trait HasMorphOwner
      * Scope a query to only include models by owner.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param \Cog\Contracts\Laravel\Ownership\CanBeOwner $owner
+     * @param \Cog\Contracts\Ownership\CanBeOwner $owner
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeWhereNotOwnedBy(Builder $query, CanBeOwnerContract $owner)

--- a/src/Traits/HasOwner.php
+++ b/src/Traits/HasOwner.php
@@ -11,12 +11,12 @@
 
 namespace Cog\Laravel\Ownership\Traits;
 
-use Cog\Contracts\Laravel\Ownership\Exceptions\InvalidDefaultOwner;
+use Cog\Contracts\Ownership\Exceptions\InvalidDefaultOwner;
 use Cog\Laravel\Ownership\Observers\OwnableObserver;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Database\Eloquent\Builder;
-use Cog\Contracts\Laravel\Ownership\Exceptions\InvalidOwnerType;
-use Cog\Contracts\Laravel\Ownership\CanBeOwner as CanBeOwnerContract;
+use Cog\Contracts\Ownership\Exceptions\InvalidOwnerType;
+use Cog\Contracts\Ownership\CanBeOwner as CanBeOwnerContract;
 
 /**
  * Class HasOwner.
@@ -26,7 +26,7 @@ use Cog\Contracts\Laravel\Ownership\CanBeOwner as CanBeOwnerContract;
 trait HasOwner
 {
     /**
-     * @var null|\Cog\Contracts\Laravel\Ownership\CanBeOwner
+     * @var null|\Cog\Contracts\Ownership\CanBeOwner
      */
     private $defaultOwner;
 
@@ -63,7 +63,7 @@ trait HasOwner
     /**
      * Get the model owner.
      *
-     * @return \Cog\Contracts\Laravel\Ownership\CanBeOwner
+     * @return \Cog\Contracts\Ownership\CanBeOwner
      */
     public function getOwner()
     {
@@ -73,7 +73,7 @@ trait HasOwner
     /**
      * Get default owner.
      *
-     * @return null|\Cog\Contracts\Laravel\Ownership\CanBeOwner
+     * @return null|\Cog\Contracts\Ownership\CanBeOwner
      */
     public function defaultOwner()
     {
@@ -83,7 +83,7 @@ trait HasOwner
     /**
      * Set owner as default for entity.
      *
-     * @param null|\Cog\Contracts\Laravel\Ownership\CanBeOwner $owner
+     * @param null|\Cog\Contracts\Ownership\CanBeOwner $owner
      * @return $this
      */
     public function withDefaultOwner(CanBeOwnerContract $owner = null)
@@ -124,7 +124,7 @@ trait HasOwner
     /**
      * Resolve entity default owner.
      *
-     * @return null|\Cog\Contracts\Laravel\Ownership\CanBeOwner
+     * @return null|\Cog\Contracts\Ownership\CanBeOwner
      */
     public function resolveDefaultOwner()
     {
@@ -134,10 +134,10 @@ trait HasOwner
     /**
      * Changes owner of the model.
      *
-     * @param \Cog\Contracts\Laravel\Ownership\CanBeOwner $owner
+     * @param \Cog\Contracts\Ownership\CanBeOwner $owner
      * @return $this
      *
-     * @throws \Cog\Contracts\Laravel\Ownership\Exceptions\InvalidOwnerType
+     * @throws \Cog\Contracts\Ownership\Exceptions\InvalidOwnerType
      */
     public function changeOwnerTo(CanBeOwnerContract $owner)
     {
@@ -172,7 +172,7 @@ trait HasOwner
     /**
      * Checks if model owned by given owner.
      *
-     * @param \Cog\Contracts\Laravel\Ownership\CanBeOwner $owner
+     * @param \Cog\Contracts\Ownership\CanBeOwner $owner
      * @return bool
      */
     public function isOwnedBy(CanBeOwnerContract $owner)
@@ -187,7 +187,7 @@ trait HasOwner
     /**
      * Checks if model not owned by given owner.
      *
-     * @param \Cog\Contracts\Laravel\Ownership\CanBeOwner $owner
+     * @param \Cog\Contracts\Ownership\CanBeOwner $owner
      * @return bool
      */
     public function isNotOwnedBy(CanBeOwnerContract $owner)
@@ -200,7 +200,7 @@ trait HasOwner
      *
      * @return bool
      *
-     * @throws \Cog\Contracts\Laravel\Ownership\Exceptions\InvalidDefaultOwner
+     * @throws \Cog\Contracts\Ownership\Exceptions\InvalidDefaultOwner
      */
     public function isOwnedByDefaultOwner()
     {
@@ -216,7 +216,7 @@ trait HasOwner
      * Scope a query to only include models by owner.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param \Cog\Contracts\Laravel\Ownership\CanBeOwner $owner
+     * @param \Cog\Contracts\Ownership\CanBeOwner $owner
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeWhereOwnedBy(Builder $query, CanBeOwnerContract $owner)
@@ -228,7 +228,7 @@ trait HasOwner
      * Scope a query to exclude models by owner.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param \Cog\Contracts\Laravel\Ownership\CanBeOwner $owner
+     * @param \Cog\Contracts\Ownership\CanBeOwner $owner
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeWhereNotOwnedBy(Builder $query, CanBeOwnerContract $owner)

--- a/tests/Stubs/Models/Character.php
+++ b/tests/Stubs/Models/Character.php
@@ -12,7 +12,7 @@
 namespace Cog\Tests\Laravel\Ownership\Stubs\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Cog\Contracts\Laravel\Ownership\CanBeOwner as CanBeOwnerContract;
+use Cog\Contracts\Ownership\CanBeOwner as CanBeOwnerContract;
 
 /**
  * Class Character.

--- a/tests/Stubs/Models/EntityWithCustomizedOwner.php
+++ b/tests/Stubs/Models/EntityWithCustomizedOwner.php
@@ -11,7 +11,7 @@
 
 namespace Cog\Tests\Laravel\Ownership\Stubs\Models;
 
-use Cog\Contracts\Laravel\Ownership\Ownable as OwnableContract;
+use Cog\Contracts\Ownership\Ownable as OwnableContract;
 use Cog\Laravel\Ownership\Traits\HasOwner;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
@@ -65,7 +65,7 @@ class EntityWithCustomizedOwner extends Model implements OwnableContract
     /**
      * Get model default owner.
      *
-     * @return null|\Cog\Contracts\Laravel\Ownership\CanBeOwner
+     * @return null|\Cog\Contracts\Ownership\CanBeOwner
      */
     public function resolveDefaultOwner()
     {

--- a/tests/Stubs/Models/EntityWithDefaultCustomizedOwner.php
+++ b/tests/Stubs/Models/EntityWithDefaultCustomizedOwner.php
@@ -11,7 +11,7 @@
 
 namespace Cog\Tests\Laravel\Ownership\Stubs\Models;
 
-use Cog\Contracts\Laravel\Ownership\Ownable as OwnableContract;
+use Cog\Contracts\Ownership\Ownable as OwnableContract;
 use Cog\Laravel\Ownership\Traits\HasOwner;
 use Illuminate\Database\Eloquent\Model;
 
@@ -66,7 +66,7 @@ class EntityWithDefaultCustomizedOwner extends Model implements OwnableContract
     /**
      * Get model default owner.
      *
-     * @return \Cog\Contracts\Laravel\Ownership\CanBeOwner
+     * @return \Cog\Contracts\Ownership\CanBeOwner
      */
     public function resolveDefaultOwner()
     {

--- a/tests/Stubs/Models/EntityWithDefaultMorphOwner.php
+++ b/tests/Stubs/Models/EntityWithDefaultMorphOwner.php
@@ -11,7 +11,7 @@
 
 namespace Cog\Tests\Laravel\Ownership\Stubs\Models;
 
-use Cog\Contracts\Laravel\Ownership\Ownable as OwnableContract;
+use Cog\Contracts\Ownership\Ownable as OwnableContract;
 use Cog\Laravel\Ownership\Traits\HasMorphOwner;
 use Illuminate\Database\Eloquent\Model;
 

--- a/tests/Stubs/Models/EntityWithDefaultOwner.php
+++ b/tests/Stubs/Models/EntityWithDefaultOwner.php
@@ -11,7 +11,7 @@
 
 namespace Cog\Tests\Laravel\Ownership\Stubs\Models;
 
-use Cog\Contracts\Laravel\Ownership\Ownable as OwnableContract;
+use Cog\Contracts\Ownership\Ownable as OwnableContract;
 use Cog\Laravel\Ownership\Traits\HasOwner;
 use Illuminate\Database\Eloquent\Model;
 

--- a/tests/Stubs/Models/EntityWithMorphOwner.php
+++ b/tests/Stubs/Models/EntityWithMorphOwner.php
@@ -11,7 +11,7 @@
 
 namespace Cog\Tests\Laravel\Ownership\Stubs\Models;
 
-use Cog\Contracts\Laravel\Ownership\Ownable as OwnableContract;
+use Cog\Contracts\Ownership\Ownable as OwnableContract;
 use Cog\Laravel\Ownership\Traits\HasMorphOwner;
 use Illuminate\Database\Eloquent\Model;
 

--- a/tests/Stubs/Models/EntityWithOwner.php
+++ b/tests/Stubs/Models/EntityWithOwner.php
@@ -11,7 +11,7 @@
 
 namespace Cog\Tests\Laravel\Ownership\Stubs\Models;
 
-use Cog\Contracts\Laravel\Ownership\Ownable as OwnableContract;
+use Cog\Contracts\Ownership\Ownable as OwnableContract;
 use Cog\Laravel\Ownership\Traits\HasOwner;
 use Illuminate\Database\Eloquent\Model;
 

--- a/tests/Stubs/Models/Group.php
+++ b/tests/Stubs/Models/Group.php
@@ -12,7 +12,7 @@
 namespace Cog\Tests\Laravel\Ownership\Stubs\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Cog\Contracts\Laravel\Ownership\CanBeOwner as CanBeOwnerContract;
+use Cog\Contracts\Ownership\CanBeOwner as CanBeOwnerContract;
 
 /**
  * Class Group.

--- a/tests/Stubs/Models/User.php
+++ b/tests/Stubs/Models/User.php
@@ -12,7 +12,7 @@
 namespace Cog\Tests\Laravel\Ownership\Stubs\Models;
 
 use Illuminate\Foundation\Auth\User as Authenticatable;
-use Cog\Contracts\Laravel\Ownership\CanBeOwner as CanBeOwnerContract;
+use Cog\Contracts\Ownership\CanBeOwner as CanBeOwnerContract;
 
 /**
  * Class User.

--- a/tests/Unit/Traits/HasCustomizedOwnerTest.php
+++ b/tests/Unit/Traits/HasCustomizedOwnerTest.php
@@ -11,11 +11,11 @@
 
 namespace Cog\Tests\Laravel\Ownership\Unit\Traits;
 
-use Cog\Contracts\Laravel\Ownership\Exceptions\InvalidDefaultOwner;
+use Cog\Contracts\Ownership\Exceptions\InvalidDefaultOwner;
 use Cog\Tests\Laravel\Ownership\TestCase;
 use Cog\Tests\Laravel\Ownership\Stubs\Models\User;
 use Cog\Tests\Laravel\Ownership\Stubs\Models\Group;
-use Cog\Contracts\Laravel\Ownership\Exceptions\InvalidOwnerType;
+use Cog\Contracts\Ownership\Exceptions\InvalidOwnerType;
 use Cog\Tests\Laravel\Ownership\Stubs\Models\EntityWithCustomizedOwner;
 use Cog\Tests\Laravel\Ownership\Stubs\Models\EntityWithDefaultCustomizedOwner;
 

--- a/tests/Unit/Traits/HasMorphOwnerTest.php
+++ b/tests/Unit/Traits/HasMorphOwnerTest.php
@@ -11,7 +11,7 @@
 
 namespace Cog\Tests\Laravel\Ownership\Unit\Traits;
 
-use Cog\Contracts\Laravel\Ownership\Exceptions\InvalidDefaultOwner;
+use Cog\Contracts\Ownership\Exceptions\InvalidDefaultOwner;
 use Cog\Tests\Laravel\Ownership\TestCase;
 use Cog\Tests\Laravel\Ownership\Stubs\Models\User;
 use Cog\Tests\Laravel\Ownership\Stubs\Models\Character;

--- a/tests/Unit/Traits/HasOwnerTest.php
+++ b/tests/Unit/Traits/HasOwnerTest.php
@@ -11,10 +11,10 @@
 
 namespace Cog\Tests\Laravel\Ownership\Unit\Traits;
 
-use Cog\Contracts\Laravel\Ownership\Exceptions\InvalidDefaultOwner;
+use Cog\Contracts\Ownership\Exceptions\InvalidDefaultOwner;
 use Cog\Tests\Laravel\Ownership\TestCase;
 use Cog\Tests\Laravel\Ownership\Stubs\Models\User;
-use Cog\Contracts\Laravel\Ownership\Exceptions\InvalidOwnerType;
+use Cog\Contracts\Ownership\Exceptions\InvalidOwnerType;
 use Cog\Tests\Laravel\Ownership\Stubs\Models\Character;
 use Cog\Tests\Laravel\Ownership\Stubs\Models\EntityWithOwner;
 use Cog\Tests\Laravel\Ownership\Stubs\Models\EntityWithDefaultOwner;

--- a/tests/database/factories/CharacterFactory.php
+++ b/tests/database/factories/CharacterFactory.php
@@ -10,9 +10,10 @@
  */
 
 use Cog\Tests\Laravel\Ownership\Stubs\Models\Character;
+use Faker\Generator;
 
 /* @var \Illuminate\Database\Eloquent\Factory $factory */
-$factory->define(Character::class, function (\Faker\Generator $faker) {
+$factory->define(Character::class, function (Generator $faker) {
     return [
         'name' => $faker->name,
     ];


### PR DESCRIPTION
Laravel Ownership v4 not following CyberCog's PHP contracts namespace convention. This release will fix it.
Additionally fixes OwnershipServiceProvider auto-discovery.