### PR TITLE
Remove kenarkose/ownable alternative in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,8 +335,6 @@ If you discover any security related issues, please email open@cybercog.su inste
 
 ## Alternatives
 
-- [kenarkose/Ownable](https://github.com/kenarkose/Ownable)
-
 *Feel free to add more alternatives as Pull Request.* 
 
 ## License


### PR DESCRIPTION
Current GitHub link 404s and packagist has marked package as [abandoned](https://packagist.org/packages/kenarkose/ownable)